### PR TITLE
Updates to sbt 1.1.1

### DIFF
--- a/src/main/g8/README.md
+++ b/src/main/g8/README.md
@@ -1,6 +1,13 @@
 A Flink application project using Scala and SBT.
 
-To run and test your application use SBT invoke: 'sbt run'
+To run and test your application locally, you can just execute `sbt run` then select the main class that contains the Flink job . 
 
-In order to run your application from within IntelliJ, you have to select the classpath of the 'mainRunner' module in the run/debug configurations.
+You can also package the application into a fat jar with `sbt assembly`, then submit it as usual, with something like: 
+
+```
+flink run -c org.example.WordCount /path/to/your/project/my-app/target/scala-2.11/testme-assembly-0.1-SNAPSHOT.jar
+```
+
+
+You can also run your application from within IntelliJ:  select the classpath of the 'mainRunner' module in the run/debug configurations.
 Simply open 'Run -> Edit configurations...' and then select 'mainRunner' from the "Use classpath of module" dropbox. 

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -22,7 +22,7 @@ lazy val root = (project in file(".")).
     libraryDependencies ++= flinkDependencies
   )
 
- assembly / mainClass := Some("$organization$.Job")
+assembly / mainClass := Some("$organization$.Job")
 
 // make run command include the provided dependencies
 Compile / run  := Defaults.runTask(Compile / fullClasspath,

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,4 +1,4 @@
-resolvers in ThisBuild ++= Seq(
+ThisBuild / resolvers ++= Seq(
     "Apache Development Snapshot Repository" at "https://repository.apache.org/content/repositories/snapshots/",
     Resolver.mavenLocal
 )
@@ -9,7 +9,7 @@ version := "$version$"
 
 organization := "$organization$"
 
-scalaVersion in ThisBuild := "$scala_version$"
+ThisBuild / scalaVersion := "$scala_version$"
 
 val flinkVersion = "$flink_version$"
 
@@ -22,13 +22,13 @@ lazy val root = (project in file(".")).
     libraryDependencies ++= flinkDependencies
   )
 
-mainClass in assembly := Some("$organization$.Job")
+ assembly / mainClass := Some("$organization$.Job")
 
 // make run command include the provided dependencies
-run in Compile := Defaults.runTask(fullClasspath in Compile,
-                                   mainClass in (Compile, run),
-                                   runner in (Compile,run)
+Compile / run  := Defaults.runTask(Compile / fullClasspath,
+                                   Compile / run / mainClass,
+                                   Compile / run / runner
                                   ).evaluated
 
 // exclude Scala library from assembly
-assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
+assembly / assemblyOption  := (assembly / assemblyOption).value.copy(includeScala = false)

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -3,5 +3,5 @@ description=A Flink Application Project Using sbt
 name=Flink Project
 organization=org.example
 version=0.1-SNAPSHOT
-scala_version=2.11.7
+scala_version=2.11.12
 flink_version=maven(org.apache.flink, flink-scala_2.11)

--- a/src/main/g8/idea.sbt
+++ b/src/main/g8/idea.sbt
@@ -1,11 +1,9 @@
 lazy val mainRunner = project.in(file("mainRunner")).dependsOn(RootProject(file("."))).settings(
   // we set all provided dependencies to none, so that they are included in the classpath of mainRunner
   libraryDependencies := (libraryDependencies in RootProject(file("."))).value.map{
-    module =>
-      if (module.configurations.equals(Some("provided"))) {
-        module.copy(configurations = None)
-      } else {
-        module
-      }
+    module => module.configurations match {
+      case Some("provided") => module.withConfigurations(None)
+      case _ => module
+    }
   }
 )

--- a/src/main/g8/project/assembly.sbt
+++ b/src/main/g8/project/assembly.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.1")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.1.1


### PR DESCRIPTION
Hi! 

I suggest to update sbt to the latest version, which is much faster and unifies the syntax between the interactive console and the script itself (see announcement [on the Lightbend blog here](https://developer.lightbend.com/blog/2017-11-30-sbt-1-1-0-RC1-sbt-server/index.html)). I also took the opportunity to update the sbt syntax in the `build.sbt` script based on this new convention. 

Also, I bumped the default scala version to 2.11.12, which is the scala version used by Flink 1.4.1

And I added some info in the readme to clarify how to build and run the project. 

Before merging, you can test this by creating a new project directly from my branch, like this 
```
sbt new sv3ndk/flink-project.g8 --branch svend/sbt_1.1.1
```


 