### PR TITLE
pressing ctrl-c during a "run" no longer exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ In order to generate a Flink project enter on the command line:
 
 ```
 $ sbt new tillrohrmann/flink-project.g8
-````
+```
 
 This will prompt for a couple of parameters (project name, scala version...) and the generate a Flink project using Scala and SBT.
 
-You can then follow the [README.md of the generated project](src/main/g8/README) for build and run instructions.
+You can then follow the [README.md of the generated project](src/main/g8/README.md) for build and run instructions.

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -30,5 +30,9 @@ Compile / run  := Defaults.runTask(Compile / fullClasspath,
                                    Compile / run / runner
                                   ).evaluated
 
+// stays inside the sbt console when we press "ctrl-c" while a Flink programme executes with "run" or "runMain"
+Compile / run / fork := true
+Global / cancelable := true
+
 // exclude Scala library from assembly
 assembly / assemblyOption  := (assembly / assemblyOption).value.copy(includeScala = false)


### PR DESCRIPTION
Hi Till, 

In the current version, when we test a Flink programme locally from the sbt console in interactive mode with `run`, then press ctrl-c, the Flink programme stops and the sbt console terminates, s.t.  we end up back in the shell prompt. 

With the two options I just added, the programme is successfully interrupted by a ctrl-c but we remain in the sbt console, which makes the development cycle slightly faster and more pleasant :) 

You can test this before merging by creating a project from my branch: 
```
 sbt new sv3ndk/flink-project.g8 --branch svend/ctrl-c-remains-in-console
```

Then type `sbt`, then `run`, select 3 to run the `WordCount` example, then press ctrl really quickly to force a termination before the count finishes by itself. 




